### PR TITLE
app/publish: improve error handling on fetch file

### DIFF
--- a/app/publish/errors.go
+++ b/app/publish/errors.go
@@ -1,0 +1,21 @@
+package publish
+
+import "fmt"
+
+// FetchError reports an error and the remote URL that caused it.
+type FetchError struct {
+	URL string
+	Err error
+}
+
+func (e *FetchError) Unwrap() error { return e.Err }
+func (e *FetchError) Error() string { return fmt.Sprintf("fetch error on %q: %s", e.URL, e.Err) }
+
+// RequestError reports an error that was due invalid request from client.
+type RequestError struct {
+	Err error
+	Msg string
+}
+
+func (e *RequestError) Unwrap() error { return e.Err }
+func (e *RequestError) Error() string { return fmt.Sprintf("request error: %s", e.Err) }

--- a/app/publish/handler_test.go
+++ b/app/publish/handler_test.go
@@ -187,7 +187,7 @@ func TestUploadHandlerSystemError(t *testing.T) {
 	var rpcResponse jsonrpc.RPCResponse
 	err = json.Unmarshal(rr.Body.Bytes(), &rpcResponse)
 	require.NoError(t, err)
-	assert.Equal(t, "unexpected EOF", rpcResponse.Error.Message)
+	assert.Equal(t, "request error: unexpected EOF", rpcResponse.Error.Message)
 	require.False(t, publisher.called)
 }
 


### PR DESCRIPTION
Before this we added a typed error on publish package to determine what
errors that should be retried and exclude request error like io.ErrUnexpectedEOF.

Problem is that error can happens on request parse too.

This commit fix the issue by separating request error and fetch error
into separate type.

Fixes #368

