### PR TITLE
app/publish: support resumable file upload

### DIFF
--- a/api/benchmarks_test.go
+++ b/api/benchmarks_test.go
@@ -73,6 +73,10 @@ func TestMain(m *testing.M) {
 	dbConn, connCleanup := storage.CreateTestConn(params)
 	dbConn.SetDefaultConnection()
 
+	// override this to temp to avoid permission error when running tests on
+	// restricted environment.
+	config.Config.Override("PublishSourceDir", os.TempDir())
+
 	code := m.Run()
 
 	connCleanup()

--- a/app/publish/errors.go
+++ b/app/publish/errors.go
@@ -1,6 +1,12 @@
 package publish
 
-import "fmt"
+import (
+	"fmt"
+
+	werrors "github.com/pkg/errors"
+)
+
+var ErrEmptyRemoteURL = &FetchError{Err: werrors.New("empty remote url")}
 
 // FetchError reports an error and the remote URL that caused it.
 type FetchError struct {
@@ -18,4 +24,4 @@ type RequestError struct {
 }
 
 func (e *RequestError) Unwrap() error { return e.Err }
-func (e *RequestError) Error() string { return fmt.Sprintf("request error: %s", e.Err) }
+func (e *RequestError) Error() string { return fmt.Sprintf("request error: %q %s", e.Msg, e.Err) }

--- a/app/publish/handler_test.go
+++ b/app/publish/handler_test.go
@@ -187,7 +187,9 @@ func TestUploadHandlerSystemError(t *testing.T) {
 	var rpcResponse jsonrpc.RPCResponse
 	err = json.Unmarshal(rr.Body.Bytes(), &rpcResponse)
 	require.NoError(t, err)
-	assert.Equal(t, "request error: unexpected EOF", rpcResponse.Error.Message)
+	if errMsg := rpcResponse.Error.Message; assert.NotNil(t, errMsg) {
+		assert.Contains(t, errMsg, "unexpected EOF")
+	}
 	require.False(t, publisher.called)
 }
 

--- a/app/publish/http.go
+++ b/app/publish/http.go
@@ -1,0 +1,115 @@
+package publish
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/lbryio/lbrytv/app/auth"
+	"github.com/lbryio/lbrytv/app/wallet"
+	"github.com/lbryio/lbrytv/internal/errors"
+	"github.com/lbryio/lbrytv/internal/ip"
+	"github.com/lbryio/lbrytv/models"
+)
+
+const (
+	// default http retries config options
+	defaultRetryWaitMin   = 5 * time.Second
+	defaultRetryWaitMax   = 30 * time.Second
+	defaultRequestTimeout = 600 * time.Second
+	defaultRetryMax       = 3
+
+	fetchTryLimit   = 3
+	fetchTimeout    = 15 * time.Minute
+	fetchRetryDelay = time.Second
+)
+
+// copied from hashicorp/go-retryablehttp/client.go
+var (
+	// A regular expression to match the error returned by net/http when the
+	// configured number of redirects is exhausted. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	redirectsErrorRe = regexp.MustCompile(`stopped after \d+ redirects\z`)
+
+	// A regular expression to match the error returned by net/http when the
+	// scheme specified in the URL is invalid. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	schemeErrorRe = regexp.MustCompile(`unsupported protocol scheme`)
+
+	// A regular expression to match the error returned by net/http when the
+	// it failed to resolve the host address. The error will be wrapped with
+	// the net/url error and another error, so for convenience we resort to
+	// match the error string instead.
+	lookupHostErrorRe = regexp.MustCompile(`dial tcp: lookup`)
+)
+
+// retryPolicy is the same as retryablehttp.DefaultRetryPolicy
+// except we log the retryable error for more verbosity and only retry
+// when connections error occured.
+func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	// check for http request error
+	if err != nil {
+		if v, ok := err.(*url.Error); ok {
+			// Don't retry if the error was due to too many redirects.
+			if redirectsErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			// Don't retry if the error was due to an invalid protocol scheme.
+			if schemeErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			// Don't retry if the error was due to TLS cert verification failure.
+			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+				return false, v
+			}
+
+			// Don't retry if the error was due to failure on host
+			// resolution.
+			if lookupHostErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+		}
+
+		// The error is likely recoverable so retry, but log the error
+		// anyway to get more info if unexpected errors causing issues
+		// in the future.
+		logger.Log().WithError(err).Warn("retrying http request")
+
+		return true, nil
+	}
+
+	// request is success, check the response code.
+	// We retry on 500-range responses to allow the server time to recover,
+	// as 500's are typically not permanent errors and may relate to outages
+	//  on the server side.
+	//
+	// This will catch invalid response codes as well, like 0 and 999.
+	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != 501) {
+		err := fmt.Errorf("unexpected HTTP status code %d", resp.StatusCode)
+		logger.Log().Error(err)
+		return true, err
+	}
+
+	return false, nil
+}
+
+// userFromRequest attempts to validate the request and return authorized user
+// if the request contains valid user access token.
+func userFromRequest(provider auth.Provider, headers http.Header, remoteAddr string) (*models.User, error) {
+	if token, ok := headers[wallet.TokenHeader]; ok {
+		addr := ip.AddressForRequest(headers, remoteAddr)
+		return provider(token[0], addr)
+	}
+	return nil, errors.Err(auth.ErrNoAuthInfo)
+}

--- a/app/publish/publish.go
+++ b/app/publish/publish.go
@@ -2,16 +2,13 @@ package publish
 
 import (
 	"context"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
@@ -47,37 +44,6 @@ const (
 	opName           = "publish"
 	fileNameParam    = "file_path"
 	remoteURLParam   = "remote_url"
-
-	// default http retries config options
-	defaultRetryWaitMin   = 5 * time.Second
-	defaultRetryWaitMax   = 30 * time.Second
-	defaultRequestTimeout = 600 * time.Second
-	defaultRetryMax       = 3
-
-	fetchTryLimit   = 3
-	fetchTimeout    = 15 * time.Minute
-	fetchRetryDelay = time.Second
-)
-
-var ErrEmptyRemoteURL = &FetchError{Err: werrors.New("empty remote url")}
-
-// copied from hashicorp/go-retryablehttp/client.go
-var (
-	// A regular expression to match the error returned by net/http when the
-	// configured number of redirects is exhausted. This error isn't typed
-	// specifically so we resort to matching on the error string.
-	redirectsErrorRe = regexp.MustCompile(`stopped after \d+ redirects\z`)
-
-	// A regular expression to match the error returned by net/http when the
-	// scheme specified in the URL is invalid. This error isn't typed
-	// specifically so we resort to matching on the error string.
-	schemeErrorRe = regexp.MustCompile(`unsupported protocol scheme`)
-
-	// A regular expression to match the error returned by net/http when the
-	// it failed to resolve the host address. The error will be wrapped with
-	// the net/url error and another error, so for convenience we resort to
-	// match the error string instead.
-	lookupHostErrorRe = regexp.MustCompile(`dial tcp: lookup`)
 )
 
 // Handler has path to save uploads to
@@ -99,61 +65,14 @@ func observeSuccess(d float64) {
 	metrics.ProxyE2ECallCounter.WithLabelValues(method).Inc()
 }
 
-// retryPolicy is the same as retryablehttp.DefaultRetryPolicy
-// except we log the retryable error for more verbosity and only retry
-// when connections error occured.
-func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	// do not retry on context.Canceled or context.DeadlineExceeded
-	if ctx.Err() != nil {
-		return false, ctx.Err()
-	}
-
-	// check for http request error
+// CanHandle checks if http.Request contains POSTed data in an accepted format.
+// Supposed to be used in gorilla mux router MatcherFunc.
+func CanHandle(r *http.Request, _ *mux.RouteMatch) bool {
+	err := r.ParseMultipartForm(32 << 20)
 	if err != nil {
-		if v, ok := err.(*url.Error); ok {
-			// Don't retry if the error was due to too many redirects.
-			if redirectsErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-
-			// Don't retry if the error was due to an invalid protocol scheme.
-			if schemeErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-
-			// Don't retry if the error was due to TLS cert verification failure.
-			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
-				return false, v
-			}
-
-			// Don't retry if the error was due to failure on host
-			// resolution.
-			if lookupHostErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-		}
-
-		// The error is likely recoverable so retry, but log the error
-		// anyway to get more info if unexpected errors causing issues
-		// in the future.
-		logger.Log().WithError(err).Warn("retrying http request")
-
-		return true, nil
+		return false
 	}
-
-	// request is success, check the response code.
-	// We retry on 500-range responses to allow the server time to recover,
-	// as 500's are typically not permanent errors and may relate to outages
-	//  on the server side.
-	//
-	// This will catch invalid response codes as well, like 0 and 999.
-	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != 501) {
-		err := fmt.Errorf("unexpected HTTP status code %d", resp.StatusCode)
-		logger.Log().Error(err)
-		return true, err
-	}
-
-	return false, nil
+	return r.FormValue(jsonRPCFieldName) != ""
 }
 
 // Handle is where HTTP upload is handled and passed on to Publisher.
@@ -298,17 +217,6 @@ func getCaller(sdkAddress, filename string, userID int, qCache cache.QueryCache)
 		return nil, nil
 	}, "")
 	return c
-}
-
-// CanHandle checks if http.Request contains POSTed data in an accepted format.
-// Supposed to be used in gorilla mux router MatcherFunc.
-func (h Handler) CanHandle(r *http.Request, _ *mux.RouteMatch) bool {
-	err := r.ParseMultipartForm(32 << 20)
-	if err != nil {
-		return false
-	}
-
-	return r.FormValue(jsonRPCFieldName) != ""
 }
 
 func (h Handler) saveFile(r *http.Request, userID int) (*os.File, error) {

--- a/app/publish/tus.go
+++ b/app/publish/tus.go
@@ -1,0 +1,234 @@
+package publish
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/lbryio/lbrytv/app/auth"
+	"github.com/lbryio/lbrytv/app/proxy"
+	"github.com/lbryio/lbrytv/app/query/cache"
+	"github.com/lbryio/lbrytv/app/rpcerrors"
+	"github.com/lbryio/lbrytv/app/sdkrouter"
+	"github.com/lbryio/lbrytv/internal/errors"
+	"github.com/lbryio/lbrytv/internal/metrics"
+	"github.com/lbryio/lbrytv/internal/monitor"
+	"github.com/lbryio/lbrytv/internal/responses"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	tusd "github.com/tus/tusd/pkg/handler"
+	"github.com/ybbus/jsonrpc"
+)
+
+const module = "publish.tus"
+
+// TusHandler handle media publishing on odysee-api, it implements TUS
+// specifications to support resumable file upload and extends the handler to
+// support fetching media from remote url.
+type TusHandler struct {
+	*tusd.UnroutedHandler
+
+	logger       monitor.ModuleLogger
+	composer     *tusd.StoreComposer
+	authProvider auth.Provider
+}
+
+// NewTusHandler creates a new publish handler.
+func NewTusHandler(authProvider auth.Provider, cfg tusd.Config, uploadPath string) (*TusHandler, error) {
+	h := &TusHandler{}
+
+	if authProvider == nil {
+		return nil, fmt.Errorf("auth provider cannot be nil")
+	}
+
+	defaultUploadPath := "./uploads"
+	if uploadPath == "" {
+		uploadPath = defaultUploadPath
+	}
+	if err := os.MkdirAll(uploadPath, os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	cfg.PreUploadCreateCallback = h.preCreateHook
+
+	handler, err := tusd.NewUnroutedHandler(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	h.UnroutedHandler = handler
+	h.logger = monitor.NewModuleLogger(module)
+	h.authProvider = authProvider
+	h.composer = cfg.StoreComposer
+
+	return h, nil
+}
+
+// Notify checks if the file upload is complete and sends jSON RPC request to lbrynet server.
+func (h TusHandler) Notify(w http.ResponseWriter, r *http.Request) {
+	log := h.logger.WithFields(
+		logrus.Fields{
+			"method_handler": "Notify",
+		},
+	)
+
+	user, err := auth.FromRequest(r)
+	if authErr := proxy.GetAuthError(user, err); authErr != nil {
+		log.WithError(authErr).Error("failed to authorize user")
+		w.Write(rpcerrors.ErrorToJSON(authErr))
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindAuth)
+		return
+	}
+	log = log.WithField("user_id", user.ID)
+
+	if sdkrouter.GetSDKAddress(user) == "" {
+		log.Errorf("user %d does not have sdk address assigned", user.ID)
+		w.Write(rpcerrors.NewInternalError(errors.Err("user does not have sdk address assigned")).JSON())
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindInternal)
+		return
+	}
+
+	params := mux.Vars(r)
+	id := params["id"]
+	if id == "" {
+		err := fmt.Errorf("file id is required")
+		log.Error(err)
+		w.Write(rpcerrors.NewInvalidParamsError(err).JSON())
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindClient)
+		return
+	}
+
+	if h.composer.UsesLocker {
+		lock, err := h.lockUpload(id)
+		if err != nil {
+			log.WithError(err).Error("failed to acquire file lock")
+			w.Write(rpcerrors.NewInternalError(err).JSON())
+			observeFailure(metrics.GetDuration(r), metrics.FailureKindInternal)
+			return
+		}
+		defer lock.Unlock()
+	}
+
+	upload, err := h.composer.Core.GetUpload(r.Context(), id)
+	if err != nil {
+		log.WithError(err).Error("failed to get upload object")
+		w.Write(rpcerrors.NewInternalError(err).JSON())
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindClient)
+		return
+	}
+
+	info, err := upload.GetInfo(r.Context())
+	if err != nil {
+		log.WithError(err).Error("failed to get upload info")
+		w.Write(rpcerrors.NewInternalError(err).JSON())
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindInternal)
+		return
+	}
+
+	// NOTE: don't use info.IsFinal as it's not reflect the upload
+	// completion at all
+	if info.Offset != info.Size { // upload is not yet completed
+		err := fmt.Errorf("upload is still in process")
+		log.WithError(err).Error("file incomplete")
+		w.Write(rpcerrors.ErrorToJSON(err))
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindClient)
+		return
+	}
+
+	// upload is completed, notify it to lbrynet server
+	var qCache cache.QueryCache
+	if cache.IsOnRequest(r) {
+		qCache = cache.FromRequest(r)
+	}
+
+	var rpcReq jsonrpc.RPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&rpcReq); err != nil {
+		w.Write(rpcerrors.NewJSONParseError(err).JSON())
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindClientJSON)
+		return
+	}
+
+	filepath := info.Storage["path"]
+
+	c := getCaller(sdkrouter.GetSDKAddress(user), filepath, user.ID, qCache)
+
+	op := metrics.StartOperation("sdk", "call_publish")
+	rpcRes, err := c.Call(&rpcReq)
+	op.End()
+	if err != nil {
+		monitor.ErrorToSentry(
+			fmt.Errorf("error calling publish: %v", err),
+			map[string]string{
+				"request":  fmt.Sprintf("%+v", rpcReq),
+				"response": fmt.Sprintf("%+v", rpcRes),
+			},
+		)
+		log.WithError(err).Errorf("error calling publish, request: %+v", rpcReq)
+		w.Write(rpcerrors.ToJSON(err))
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindRPC)
+		return
+	}
+
+	serialized, err := responses.JSONRPCSerialize(rpcRes)
+	if err != nil {
+		log.WithError(err).Error("error marshalling response")
+		monitor.ErrorToSentry(err)
+		w.Write(rpcerrors.NewInternalError(err).JSON())
+		observeFailure(metrics.GetDuration(r), metrics.FailureKindRPCJSON)
+		return
+	}
+
+	// remove the file from local server
+	terminatableUpload := h.composer.Terminater.AsTerminatableUpload(upload)
+	if err := terminatableUpload.Terminate(r.Context()); err != nil {
+		log.WithError(err).Error("failed to remove file")
+		monitor.ErrorToSentry(err, map[string]string{"file_path": filepath})
+	}
+
+	w.Write(serialized)
+	observeSuccess(metrics.GetDuration(r))
+}
+
+func (h TusHandler) lockUpload(id string) (tusd.Lock, error) {
+	lock, err := h.composer.Locker.NewLock(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := lock.Lock(); err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
+// preCreateHook validates user access request to publish handler before we
+// attempt to start the upload procedures.
+//
+// Note that usually this should be done as part of http middleware, but TUS
+// handlers overwrite the context with context background to avoid context
+// cancellation, and so any attempt to read values from request context won't
+// work here, until they can safely pass request context to TUS handler we need
+// to decouple before and after middleware to TUS hook callback functions.
+//
+// see: https://github.com/tus/tusd/pull/342
+func (h *TusHandler) preCreateHook(hook tusd.HookEvent) error {
+	log := h.logger.WithFields(
+		logrus.Fields{
+			"method_handler": "preCreateHook",
+		},
+	)
+
+	r := hook.HTTPRequest
+	user, err := userFromRequest(h.authProvider, r.Header, r.RemoteAddr)
+	if err != nil {
+		log.WithError(err).Info("error authenticating user")
+		return err
+	}
+	if user == nil {
+		err := auth.ErrNoAuthInfo
+		log.WithError(err).Info("unauthorized user")
+		return err
+	}
+	return nil
+}

--- a/app/publish/tus_test.go
+++ b/app/publish/tus_test.go
@@ -1,0 +1,432 @@
+package publish
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lbryio/lbrytv/app/auth"
+	"github.com/lbryio/lbrytv/app/wallet"
+	"github.com/lbryio/lbrytv/internal/errors"
+	"github.com/lbryio/lbrytv/internal/test"
+	"github.com/lbryio/lbrytv/models"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/tus/tusd/pkg/filestore"
+	tusd "github.com/tus/tusd/pkg/handler"
+)
+
+func newTusTestCfg(uploadPath string) tusd.Config {
+	composer := tusd.NewStoreComposer()
+	store := filestore.FileStore{
+		Path: uploadPath,
+	}
+	store.UseIn(composer)
+	return tusd.Config{
+		BasePath:      "/api/v2/publish/",
+		StoreComposer: composer,
+	}
+}
+
+func newTestTusHandler(t *testing.T) *TusHandler {
+	t.Helper()
+
+	uploadPath := os.TempDir()
+
+	h, err := NewTusHandler(
+		mockAuthProvider,
+		newTusTestCfg(uploadPath),
+		uploadPath,
+	)
+	assert.Nil(t, err)
+	return h
+}
+
+// tr is a helper to construct publish route path
+var tr testRoute = "/api/v2/publish"
+
+type testRoute string
+
+func (tr testRoute) withID(id int) string {
+	return fmt.Sprintf("%s/%d", tr, id)
+}
+
+func (tr testRoute) notify(id int) string {
+	return fmt.Sprintf("%s/%d/notify", tr, id)
+}
+
+func (tr testRoute) root() string {
+	return fmt.Sprintf("%s/", tr)
+}
+
+func mockAuthProvider(token, ip string) (*models.User, error) {
+	reqChan := test.ReqChan()
+	ts := test.MockHTTPServer(reqChan)
+	var u *models.User
+	if token == "uPldrToken" {
+		u = &models.User{ID: 20404}
+		u.R = u.R.NewStruct()
+		u.R.LbrynetServer = &models.LbrynetServer{Address: ts.URL}
+	}
+	go func() {
+		ts.NextResponse <- expectedStreamCreateResponse
+	}()
+	return u, nil
+}
+
+func newTestMux(h *TusHandler, mwf ...mux.MiddlewareFunc) *mux.Router {
+	router := mux.NewRouter()
+
+	testRouter := router.PathPrefix("/api/v2/publish").Subrouter()
+	for _, fn := range mwf {
+		testRouter.Use(fn)
+	}
+
+	testRouter.HandleFunc("/", h.PostFile).Methods(http.MethodPost)
+	testRouter.HandleFunc("/{id}", h.HeadFile).Methods(http.MethodHead)
+	testRouter.HandleFunc("/{id}", h.PatchFile).Methods(http.MethodPatch)
+	testRouter.HandleFunc("/{id}/notify", h.Notify).Methods(http.MethodPost)
+
+	return testRouter
+}
+
+func newPartialUpload(t *testing.T, h *TusHandler) string {
+	t.Helper()
+
+	testData := []byte("test file")
+	r, err := http.NewRequest(http.MethodPost, tr.root(), bytes.NewReader(testData))
+	assert.Nil(t, err)
+
+	r.Header.Set(wallet.TokenHeader, "uPldrToken")
+	r.Header.Set("Upload-Length", fmt.Sprintf("%d", len(testData)))
+
+	w := httptest.NewRecorder()
+	newTestMux(h).ServeHTTP(w, r)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	return resp.Header.Get("location")
+}
+
+func newFinalUpload(t *testing.T, h *TusHandler) string {
+	loc := newPartialUpload(t, h)
+
+	testData := []byte("test file")
+	r, err := http.NewRequest(http.MethodPatch, loc, bytes.NewReader(testData))
+	assert.Nil(t, err)
+
+	r.Header.Set(wallet.TokenHeader, "uPldrToken")
+	r.Header.Set("Content-Type", "application/offset+octet-stream")
+	r.Header.Set("Upload-Offset", "0")
+
+	w := httptest.NewRecorder()
+	newTestMux(h).ServeHTTP(w, r)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	return loc
+}
+
+func TestNewTusHandler(t *testing.T) {
+	t.Parallel()
+
+	successTestCases := []struct {
+		name string
+		fn   func() (auth.Provider, tusd.Config, string)
+	}{
+		{
+			name: "WithExistingDirectory",
+			fn: func() (auth.Provider, tusd.Config, string) {
+				uploadPath := os.TempDir()
+				return mockAuthProvider, newTusTestCfg(uploadPath), uploadPath
+			},
+		},
+		{
+			name: "WithNewDirectory",
+			fn: func() (auth.Provider, tusd.Config, string) {
+				uploadPath := filepath.Join(os.TempDir(), "new_dir")
+				return mockAuthProvider, newTusTestCfg(uploadPath), uploadPath
+			},
+		},
+	}
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		for _, test := range successTestCases {
+			test := test
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
+				h, err := NewTusHandler(test.fn())
+				assert.Nil(t, err)
+				assert.NotNil(t, h)
+			})
+		}
+	})
+
+	errorTestCases := []struct {
+		name    string
+		fn      func() (auth.Provider, tusd.Config, string)
+		wantErr error
+	}{
+		{
+			name: "WithNilAuthProvider",
+			fn: func() (auth.Provider, tusd.Config, string) {
+				uploadPath := os.TempDir()
+				return nil, newTusTestCfg(uploadPath), uploadPath
+			},
+		},
+		{
+			name: "WithRestrictedDirectoryAccess",
+			fn: func() (auth.Provider, tusd.Config, string) {
+				if err := os.Mkdir("test_dir", 0444); err != nil { // read only
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					if err := os.Remove("test_dir"); err != nil {
+						t.Fatal(err)
+					}
+				})
+				uploadPath := filepath.Join("test_dir", "new_dir")
+				return mockAuthProvider, newTusTestCfg(uploadPath), uploadPath
+			},
+			wantErr: os.ErrPermission,
+		},
+	}
+	t.Run("Error", func(t *testing.T) {
+		t.Parallel()
+		for _, test := range errorTestCases {
+			test := test
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := NewTusHandler(test.fn())
+				assert.NotNil(t, err)
+
+				if test.wantErr != nil {
+					if err = errors.Unwrap(err); !errors.Is(err, test.wantErr) {
+						t.Fatalf("expecting error: %+v, got: %+v", test.wantErr, err)
+					}
+				}
+			})
+		}
+	})
+}
+
+func TestNotify(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithNoMiddleware", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		r, err := http.NewRequest(http.MethodPost, tr.notify(77), nil)
+		assert.Nil(t, err)
+
+		newTestMux(h).ServeHTTP(w, r)
+
+		respBody, err := ioutil.ReadAll(w.Result().Body)
+		assert.Nil(t, err)
+
+		wantErrMsg := "auth.Middleware is required"
+		gotErrMsg := test.StrToRes(t, string(respBody)).Error.Message
+		assert.Equal(t, wantErrMsg, gotErrMsg)
+	})
+
+	t.Run("FileNotExist", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		r, err := http.NewRequest(http.MethodPost, tr.notify(404), nil)
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+		newTestMux(h, auth.Middleware(mockAuthProvider)).ServeHTTP(w, r)
+
+		respBody, err := ioutil.ReadAll(w.Result().Body)
+		assert.Nil(t, err)
+
+		wantErrMsg := "no such file or directory"
+		gotErrMsg := test.StrToRes(t, string(respBody)).Error.Message
+		assert.Contains(t, gotErrMsg, wantErrMsg)
+	})
+
+	t.Run("UploadInProgress", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		loc := newPartialUpload(t, h)
+
+		r, err := http.NewRequest(http.MethodPost, loc+"/notify", http.NoBody)
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+		newTestMux(h, auth.Middleware(mockAuthProvider)).ServeHTTP(w, r)
+
+		respBody, err := ioutil.ReadAll(w.Result().Body)
+		assert.Nil(t, err)
+
+		wantErrMsg := "upload is still in process"
+		gotErrMsg := test.StrToRes(t, string(respBody)).Error.Message
+		assert.Equal(t, wantErrMsg, gotErrMsg)
+
+		f, err := os.Stat(filepath.Join(os.TempDir(), path.Base(loc)))
+		assert.Nil(t, err)
+		assert.NotNil(t, f)
+	})
+
+	t.Run("UploadCompleted", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		loc := newFinalUpload(t, h)
+
+		r, err := http.NewRequest(
+			http.MethodPost, loc+"/notify",
+			strings.NewReader(expectedStreamCreateRequest),
+		)
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+		newTestMux(h, auth.Middleware(mockAuthProvider)).ServeHTTP(w, r)
+
+		response := w.Result()
+		respBody, err := ioutil.ReadAll(response.Body)
+		assert.Nil(t, err)
+
+		test.AssertEqualJSON(t, expectedStreamCreateResponse, respBody)
+
+		f, err := os.Stat(filepath.Join(os.TempDir(), path.Base(loc)))
+		assert.Nil(t, f)
+		assert.NotNil(t, err)
+	})
+}
+
+func TestTus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FailedToAuthorize", func(t *testing.T) {
+		t.Parallel()
+
+		errAuthFn := func(token, ip string) (*models.User, error) {
+			return nil, fmt.Errorf("failed to authorize")
+		}
+
+		uploadPath := os.TempDir()
+		h, err := NewTusHandler(
+			errAuthFn,
+			newTusTestCfg(uploadPath),
+			uploadPath,
+		)
+		assert.Nil(t, err)
+
+		w := httptest.NewRecorder()
+
+		r, err := http.NewRequest(http.MethodPost, tr.root(), http.NoBody)
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+		newTestMux(h).ServeHTTP(w, r)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("CreateUpload", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		testData := []byte("test file")
+		r, err := http.NewRequest(http.MethodPost, tr.root(), bytes.NewReader(testData))
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+		r.Header.Set("Upload-Length", fmt.Sprintf("%d", len(testData)))
+
+		newTestMux(h).ServeHTTP(w, r)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		assert.NotEmpty(t, resp.Header.Get("location"))
+	})
+
+	t.Run("ResumeUpload", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		loc := newPartialUpload(t, h)
+
+		testData := []byte("test file")
+		r, err := http.NewRequest(http.MethodPatch, loc, bytes.NewReader(testData))
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+		r.Header.Set("Content-Type", "application/offset+octet-stream")
+		r.Header.Set("Upload-Offset", "0")
+
+		newTestMux(h).ServeHTTP(w, r)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("QueryFile", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+
+		loc := newPartialUpload(t, h)
+
+		r, err := http.NewRequest(http.MethodHead, loc, http.NoBody)
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+		newTestMux(h).ServeHTTP(w, r)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("QueryNonExistentFile", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestTusHandler(t)
+		w := httptest.NewRecorder()
+		_ = newPartialUpload(t, h)
+
+		r, err := http.NewRequest(http.MethodHead, tr.withID(404), http.NoBody)
+		assert.Nil(t, err)
+
+		r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+		newTestMux(h).ServeHTTP(w, r)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tus/tusd v1.6.0
 	github.com/volatiletech/inflect v0.0.1 // indirect
 	github.com/volatiletech/null v8.0.0+incompatible
 	github.com/volatiletech/sqlboiler v3.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.37.0/go.mod h1:TS1dMSSfndXH133OKGwekG838Om/cQT0BUHV3HcBgoo=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
+cloud.google.com/go v0.40.0/go.mod h1:Tk58MuI9rbLMKlAjeO/bDnteAx7tX2gJIXw4T5Jwlro=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
@@ -69,6 +70,7 @@ github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:o
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.16.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.20.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
@@ -86,6 +88,8 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
+github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
+github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3 h1:A/EVblehb75cUgXA5njHPn0kLAsykn6mJGz7rnmW5W0=
@@ -352,12 +356,14 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -424,11 +430,13 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -652,6 +660,7 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
@@ -786,6 +795,7 @@ github.com/sebdah/goldie v0.0.0-20190531093107-d313ffb52c77/go.mod h1:jXP4hmWywN
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
 github.com/sfreiberg/gotwilio v0.0.0-20180612161623-8fb7259ba8bf/go.mod h1:60PiR0SAnAcYSiwrXB6BaxeqHdXMf172toCosHfV+Yk=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
@@ -879,6 +889,8 @@ github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cb
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tus/tusd v1.6.0 h1:IU9Z2Z5FZfHIap6NPFbPItyx/eU6aN87z4ya/mPzS4g=
+github.com/tus/tusd v1.6.0/go.mod h1:ygrT4B9ZSb27dx3uTnobX5nOFDnutBL6iWKLH4+KpA0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -895,6 +907,7 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vimeo/go-util v1.2.0/go.mod h1:s13SMDTSO7AjH1nbgp707mfN5JFIWUFDU5MDDuRRtKs=
 github.com/volatiletech/inflect v0.0.0-20170731032912-e7201282ae8d/go.mod h1:jspfvgf53t5NLUT4o9L1IX0kIBNKamGq1tWc/MgWK9Q=
 github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwvE8KsU=
 github.com/volatiletech/inflect v0.0.1/go.mod h1:IBti31tG6phkHitLlr5j7shC5SOo//x0AjDzaJU1PLA=
@@ -1207,6 +1220,7 @@ google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+
 google.golang.org/api v0.1.0/go.mod h1:UGEZY7KEX120AnNLIHFMKIo4obdJhkp2tPbaPlQx13Y=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -1255,6 +1269,7 @@ google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRn
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
@@ -1273,6 +1288,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/Acconut/lockfile.v1 v1.1.0/go.mod h1:6UCz3wJ8tSFUsPR6uP/j8uegEtDuEEqFxlpi0JI4Umw=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -1290,6 +1306,7 @@ gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/R
 gopkg.in/gorp.v1 v1.7.1/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
 gopkg.in/gorp.v1 v1.7.2 h1:j3DWlAyGVv8whO7AcIWznQ2Yj7yJkn34B8s63GViAAw=
 gopkg.in/gorp.v1 v1.7.2/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
+gopkg.in/h2non/gock.v1 v1.0.14/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.41.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.48.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/internal/ip/ip.go
+++ b/internal/ip/ip.go
@@ -13,7 +13,7 @@ var logger = monitor.NewModuleLogger("ip")
 
 // most of this is from https://husobee.github.io/golang/ip-address/2015/12/17/remote-ip-go.html
 
-//ipRange holds the start and end of a range of ip addresses
+// ipRange holds the start and end of a range of ip addresses
 type ipRange struct {
 	start net.IP
 	end   net.IP
@@ -71,9 +71,9 @@ func IsPrivateSubnet(ipAddress net.IP) bool {
 }
 
 // AddressForRequest returns the real IP address of the request
-func AddressForRequest(r *http.Request) string {
+func AddressForRequest(headers http.Header, remoteAddr string) string {
 	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
-		addresses := strings.Split(r.Header.Get(h), ",")
+		addresses := strings.Split(headers.Get(h), ",")
 		// march from right to left until we get a public address
 		// that will be the address right before our proxy.
 		for i := len(addresses) - 1; i >= 0; i-- {
@@ -88,7 +88,7 @@ func AddressForRequest(r *http.Request) string {
 		}
 	}
 
-	ipParts := strings.Split(r.RemoteAddr, ":")
+	ipParts := strings.Split(remoteAddr, ":")
 	addr := strings.Join(ipParts[:len(ipParts)-1], ":")
 
 	if addr == "[::1]" {

--- a/internal/ip/ip_test.go
+++ b/internal/ip/ip_test.go
@@ -23,7 +23,7 @@ func TestAddressForRequest(t *testing.T) {
 		t.Run(val, func(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodGet, "", nil)
 			r.Header.Add("X-Forwarded-For", val)
-			assert.Equal(t, exp, AddressForRequest(r))
+			assert.Equal(t, exp, AddressForRequest(r.Header, r.RemoteAddr))
 		})
 	}
 }

--- a/internal/ip/middleware.go
+++ b/internal/ip/middleware.go
@@ -22,7 +22,7 @@ func FromRequest(r *http.Request) string {
 // Middleware will attach remote user IP to every request
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		remoteIP := AddressForRequest(r)
+		remoteIP := AddressForRequest(r.Header, r.RemoteAddr)
 		next.ServeHTTP(w, r.Clone(context.WithValue(r.Context(), contextKey, remoteIP)))
 	})
 }

--- a/internal/metrics/routes_test.go
+++ b/internal/metrics/routes_test.go
@@ -3,9 +3,11 @@ package metrics_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/lbryio/lbrytv/api"
+	"github.com/lbryio/lbrytv/apps/lbrytv/config"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -48,6 +50,10 @@ func testMetricUIEvent(t *testing.T, method, name, value string) *httptest.Respo
 		q.Add("value", value)
 	}
 	req.URL.RawQuery = q.Encode()
+
+	// override this to temp to avoid permission error when running tests on
+	// restricted environment.
+	config.Config.Override("PublishSourceDir", os.TempDir())
 
 	r := mux.NewRouter()
 	api.InstallRoutes(r, nil)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,6 +29,10 @@ func TestMain(m *testing.M) {
 
 	defer connCleanup()
 
+	// override this to temp to avoid permission error when running tests on
+	// restricted environment.
+	config.Config.Override("PublishSourceDir", os.TempDir())
+
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This introduces 3 new endpoints that implements TUS protocol.

- POST	/api/v2/publish
- PATCH /api/v2/publish/{file_id}
- HEAD	/api/v2/publish/{file_id}

And one more endpoint to interact with lbrynet server after the upload
is completed.

- POST /api/v2/publis/{file_id}/notify

What changes from the old publishing implementation are:
   - Now the upload procedures will be handled exclusively by TUS
     handlers (PostFile, PatchFile, and HeadFile)
   - Upon upload completion, client need to call Notify endpoint to
     inform odysee to forward the publishing request to lbrynet server.
   - User authentication happens on preUploadCreateHook

Fix #202