### PR TITLE
(#370) Do not log all JSON-RPC parameters

### DIFF
--- a/app/query/caller.go
+++ b/app/query/caller.go
@@ -259,9 +259,12 @@ func (c *Caller) SendQuery(q *Query) (*jsonrpc.RPCResponse, error) {
 		"user_id":  c.userID,
 		"duration": c.Duration,
 	}
-	// Don't log query params for "sync_apply" method
+	// Don't log query params for "sync_apply" method,
+	// and also log only some entries of lists to avoid clogging
 	if q.Method() != MethodSyncApply {
-		logFields["params"] = q.Params()
+		paramMap := q.ParamsAsMap()
+		paramCut := cutSublistsToSize(paramMap, maxListSizeLogged)
+		logFields["params"] = paramCut
 	}
 	logEntry := logger.WithFields(logFields)
 
@@ -361,4 +364,23 @@ func isErrWalletNotLoaded(r *jsonrpc.RPCResponse) bool {
 
 func isErrWalletAlreadyLoaded(r *jsonrpc.RPCResponse) bool {
 	return r.Error != nil && errors.Is(lbrynet.NewWalletError(0, errors.Err(r.Error.Message)), lbrynet.ErrWalletAlreadyLoaded)
+}
+
+// Makes a shallow copy of a map, cutting the size of the lists inside it
+// to at most num, made for declogging logs
+func cutSublistsToSize(m map[string]interface{}, num int) map[string]interface{} {
+	ret := make(map[string]interface{}, len(m))
+	for key, value := range m {
+		switch value.(type) {
+		case []interface{}:
+			if len(value.([]interface{})) < num {
+				ret[key] = value
+			} else {
+				ret[key] = value.([]interface{})[0:num]
+			}
+		default:
+			ret[key] = value
+		}
+	}
+	return ret
 }

--- a/app/query/const.go
+++ b/app/query/const.go
@@ -2,6 +2,7 @@ package query
 
 const (
 	cacheResolveLongerThan = 10
+	maxListSizeLogged      = 5
 
 	MethodGet              = "get"
 	MethodFileList         = "file_list"
@@ -71,7 +72,7 @@ var walletSpecificMethods = []string{
 	"channel_export",
 	"channel_import",
 	"channel_sign",
-	
+
 	"collection_list",
 	"collection_create",
 	"collection_update",


### PR DESCRIPTION
I was able to solve this issue by creating a function to copy the map of parameters and cut lists inside it to only a fixed size, then this shallow copy is the one that gets logged. I hope this implementation is acceptable.